### PR TITLE
Refactor CI workflow: remove push trigger and rename job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,10 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
-      - master
+  workflow_dispatch:
 
 jobs:
-  lint-and-test:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Updated the GitHub Actions CI workflow configuration to simplify the trigger conditions and clarify job naming.

## Key Changes
- Removed automatic `push` trigger for `main` and `master` branches
- Added `workflow_dispatch` trigger to allow manual workflow execution
- Renamed `lint-and-test` job to `build-and-test` for better clarity of job responsibilities
- CI now runs only on pull requests and manual triggers

## Implementation Details
The workflow will now trigger in two scenarios:
1. On any pull request (existing behavior maintained)
2. On manual dispatch via the GitHub Actions UI (new capability)

This change reduces unnecessary CI runs on direct pushes while maintaining pull request validation and enabling on-demand workflow execution.

https://claude.ai/code/session_012DKGSbhdNvkT6bfdKfjJtB